### PR TITLE
Add redirect to YouTube on 'View Details' action

### DIFF
--- a/frontend/src/components/launchpad-form.tsx
+++ b/frontend/src/components/launchpad-form.tsx
@@ -255,6 +255,7 @@ export function LaunchpadForm() {
         action: {
           label: "View Details",
           onClick: () => {
+            window.location.href = "https://youtube.com"; // Redirect to YouTube
             console.log("Viewing token details:", {
               organizationId: organizationResponse.id,
               tokenId: tokenResponse.id,


### PR DESCRIPTION
The 'View Details' button now redirects users to YouTube by setting window.location.href. This change was added to the onClick handler for the action.