### PR TITLE
Add console log when redirecting to YouTube

### DIFF
--- a/frontend/src/components/launchpad-form.tsx
+++ b/frontend/src/components/launchpad-form.tsx
@@ -255,7 +255,8 @@ export function LaunchpadForm() {
         action: {
           label: "View Details",
           onClick: () => {
-            window.location.href = "https://youtube.com"; // Redirect to YouTube
+            window.location.href = "https://youtube.com";
+            console.log("Youtube added") // Redirect to YouTube
             console.log("Viewing token details:", {
               organizationId: organizationResponse.id,
               tokenId: tokenResponse.id,


### PR DESCRIPTION
A console log statement was added before redirecting to YouTube in the launchpad form's action handler to indicate when the redirect occurs.