### PR TITLE
Update redirect URL in launchpad form

### DIFF
--- a/frontend/src/components/launchpad-form.tsx
+++ b/frontend/src/components/launchpad-form.tsx
@@ -255,7 +255,7 @@ export function LaunchpadForm() {
         action: {
           label: "View Details",
           onClick: () => {
-            window.location.href = "https://youtube.com";
+            window.location.href = "creda-demo-project.vercel.app";
             console.log("Youtube added") // Redirect to YouTube
             console.log("Viewing token details:", {
               organizationId: organizationResponse.id,


### PR DESCRIPTION
Changed the redirect URL from YouTube to creda-demo-project.vercel.app in the LaunchpadForm component's action handler.